### PR TITLE
Implement quick scan page cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A hassle-free GUI tool to recursively download full-size images from any Copperm
 - Preserves structure — Downloads images into folders/subfolders that match the gallery’s layout
 - Download progress & log — See what’s happening at every step
 - Adaptive scraping engine — Handles custom Coppermine themes, multi-page albums, custom anti-hotlinking, and referer requirements
-- Caching for speed — Caches the discovered gallery tree locally and, on repeat runs, only scans albums that have changed—so you don’t re-crawl the entire site every time (great for massive sites)
+- Quick scan caching — Saves HTML of each visited page. Subsequent runs hit the network only if a page has changed or the cache expired.
 - “Mimic human behavior” — Optionally randomizes download order and timing to avoid hammering servers (toggle in the GUI)
 - Windows double-click support — via `start_gallery_ripper.bat`
 - Compatible with Python 3.10+


### PR DESCRIPTION
## Summary
- redesign caching to store per-page HTML and metadata
- add quick scan mode to skip unchanged pages
- expose quick scan toggle in the GUI
- update docs about caching

## Testing
- `python -m py_compile gallery_ripper.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686e445be8b08320a42be3c9a3163805