### PR TITLE
Add rule-based universal gallery adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Copperminer – A Gallery Ripper
 
-A hassle-free GUI tool to recursively download full-size images from any Coppermine-powered gallery—including multi-album and deeply nested sites. No thumbnails, no junk—just the real full-size images, organized in folders to match the site’s gallery structure. Perfect for backing up fan galleries before they disappear.
+A hassle-free GUI tool to recursively download full-size images from any Coppermine-powered gallery—plus other sites using a simple rules engine (ThePlace2 included). No thumbnails, no junk—just the real full-size images, organized in folders to match the site’s gallery structure. Perfect for backing up fan galleries before they disappear.
 
 ## Features
 
 - Point-and-click GUI — No command line needed, always-on dark mode
-- Intelligent discovery — Enter any gallery root or album URL (works with multi-level Coppermine sites)
+- Intelligent discovery — Enter any gallery root or album URL (supports Coppermine and rule-based sites like ThePlace2)
 - Album tree — Finds and displays all real albums for selection, ignoring “Last uploads”, “Most viewed”, and other virtual/special albums
 - Optional special galleries toggle — Include “Last uploads”, “Most viewed”, etc. only when you want them
 - Preserves structure — Downloads images into folders/subfolders that match the gallery’s layout
@@ -22,7 +22,7 @@ A hassle-free GUI tool to recursively download full-size images from any Copperm
 
 ## Limitations
 
-- Coppermine only: Not intended for non-Coppermine galleries (results will likely be incomplete or fail)
+- Supports Coppermine and a small set of rule-based sites (initially ThePlace2): other galleries may fail
 - No thumbnails or junk: Only saves original/full-size images—not previews, icons, or other irrelevant files
 - Not for commercial use: See license below
 


### PR DESCRIPTION
## Summary
- generalize the recently added ThePlace2 support into a rules-driven Universal adapter
- select the universal adapter automatically when a ruleset matches
- use universal functions when discovering and ripping galleries
- document the new rules approach in the README

## Testing
- `python -m py_compile gallery_ripper.py`


------
https://chatgpt.com/codex/tasks/task_e_686e89b747b083208f656807581e8fc2