### PR TITLE
Improve filtering of gallery images

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A hassle-free GUI tool to recursively download full-size images from any Copperm
 ## Limitations
 
 - Supports Coppermine and a small set of rule-based sites (initially ThePlace2): other galleries may fail
-- No thumbnails or junk: Only saves original/full-size images—not previews, icons, or other irrelevant files
+- No thumbnails or junk: heuristically skips thumbnails and UI icons to save only the original images
 - Not for commercial use: See license below
 
 ## Installation


### PR DESCRIPTION
## Summary
- add helpers to skip UI images and thumbnails
- filter candidate lists using the helpers
- mention heuristics in README

## Testing
- `python -m py_compile gallery_ripper.py`

------
https://chatgpt.com/codex/tasks/task_e_686eaa949c588320abca27b9c07b684c