### PR TITLE
Improve proxy pool replenish speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A hassle-free GUI tool to recursively download full-size images from any Copperm
 - Windows double-click support — via `start_gallery_ripper.bat`
 - One-click self-update from Git — pull new commits and restart automatically
 - Compatible with Python 3.10+
-- Dynamic proxy pool — Harvests and validates free proxies automatically (HTTP/HTTPS) and refreshes periodically; UI shows last check time
+- Dynamic proxy pool with caching — Harvests and validates free proxies automatically, caches results to skip dead proxies, and fast-fills the pool for quick startup; UI shows last check time
 
 ## Limitations
 

--- a/proxy_manager.py
+++ b/proxy_manager.py
@@ -3,6 +3,9 @@ import aiohttp
 import random
 import time
 import warnings
+import json
+import os
+from typing import Callable, Optional
 
 warnings.filterwarnings("ignore", category=ResourceWarning)
 
@@ -16,19 +19,95 @@ PROXY_SOURCES = [
 ]
 
 MIN_PROXIES = 40
-VALIDATION_CONCURRENCY = 40
+VALIDATION_CONCURRENCY = 30
+
+PROXY_CACHE_FILE = "proxy_cache.json"
+CACHE_TTL_GOOD = 6 * 60 * 60  # 6 hours
+CACHE_TTL_BAD = 12 * 60 * 60  # 12 hours
+
+
+class ProxyCache:
+    def __init__(self, filename: str = PROXY_CACHE_FILE):
+        self.filename = filename
+        self.cache: dict[str, dict] = {}
+        self.load()
+
+    def load(self) -> None:
+        if os.path.exists(self.filename):
+            try:
+                with open(self.filename, "r", encoding="utf-8") as f:
+                    self.cache = json.load(f)
+            except Exception:
+                self.cache = {}
+
+    def save(self) -> None:
+        try:
+            with open(self.filename, "w", encoding="utf-8") as f:
+                json.dump(self.cache, f, indent=2)
+        except Exception:
+            pass
+
+    def update(self, proxy: str, status: str) -> None:
+        self.cache[proxy] = {
+            "status": status,
+            "last_test": time.time(),
+        }
+
+    def should_test(self, proxy: str) -> bool:
+        entry = self.cache.get(proxy)
+        now = time.time()
+        if not entry:
+            return True
+        if entry["status"] == "good" and now - entry["last_test"] < CACHE_TTL_GOOD:
+            return False
+        if entry["status"] == "bad" and now - entry["last_test"] < CACHE_TTL_BAD:
+            return False
+        return True
+
+    def get_good_proxies(self) -> list[str]:
+        now = time.time()
+        return [
+            p
+            for p, e in self.cache.items()
+            if e.get("status") == "good" and now - e.get("last_test", 0) < CACHE_TTL_GOOD
+        ]
 
 
 class ProxyPool:
     """Async proxy pool that keeps itself topped up."""
 
-    def __init__(self, min_proxies: int = MIN_PROXIES):
-        self.pool: list[str] = []
+    def __init__(
+        self,
+        min_proxies: int = MIN_PROXIES,
+        cache_file: str = PROXY_CACHE_FILE,
+        fast_fill: int = 10,
+        ready_callback: Optional[Callable[[], None]] = None,
+    ) -> None:
+        self.cache = ProxyCache(cache_file)
+        self.pool: list[str] = list(dict.fromkeys(self.cache.get_good_proxies()))
         self.min_proxies = min_proxies
+        self.fast_fill = fast_fill
+        self.ready_callback = ready_callback
+        self.pool_ready = False
         self.lock = asyncio.Lock()
         self.refresh_task: asyncio.Task | None = None
         self.last_checked: float = 0.0
         self.sema = asyncio.Semaphore(VALIDATION_CONCURRENCY)
+        self.ready_event = asyncio.Event()
+
+    def _signal_ready(self) -> None:
+        if not self.pool_ready:
+            self.pool_ready = True
+            self.ready_event.set()
+            if self.ready_callback:
+                try:
+                    self.ready_callback()
+                except Exception:
+                    pass
+
+    async def wait_until_ready(self) -> None:
+        """Wait until the pool has at least *fast_fill* proxies."""
+        await self.ready_event.wait()
 
     async def fetch_proxies(self) -> set[str]:
         proxies: set[str] = set()
@@ -61,21 +140,65 @@ class ProxyPool:
         print(f"[PROXY] BAD: {proxy}")
         return False
 
-    async def replenish(self) -> None:
+    async def _finish_tasks(self, tasks: dict[asyncio.Task, str]) -> None:
+        """Background task to finalize validation of *tasks*."""
+        for t in tasks:
+            try:
+                ok = await t
+            except Exception:
+                ok = False
+            proxy = tasks[t]
+            self.cache.update(proxy, "good" if ok else "bad")
+            if ok and proxy not in self.pool:
+                self.pool.append(proxy)
+        self.cache.save()
+        if len(self.pool) >= self.fast_fill:
+            self._signal_ready()
+
+    async def replenish(self, fast_fill: int | None = None) -> None:
         async with self.lock:
             print("[PROXY] Replenishing proxies...")
+
+            fast_fill = fast_fill or self.fast_fill
+
+            # Load cached good proxies first
+            for p in self.cache.get_good_proxies():
+                if p not in self.pool:
+                    self.pool.append(p)
+            if len(self.pool) >= fast_fill:
+                self.last_checked = time.time()
+                self.cache.save()
+                print(f"[PROXY] Fast pool fill from cache: {len(self.pool)} proxies.")
+                self._signal_ready()
+                return
+
             raw = await self.fetch_proxies()
-            to_test = list(raw - set(self.pool))
-            tasks = [self.validate_proxy(p) for p in to_test]
-            results = await asyncio.gather(*tasks)
-            for proxy, ok in zip(to_test, results):
-                if ok:
+            to_test = [p for p in raw if self.cache.should_test(p)]
+            task_map = {asyncio.create_task(self.validate_proxy(p)): p for p in to_test}
+            good_found = 0
+
+            for fut in asyncio.as_completed(list(task_map.keys())):
+                ok = await fut
+                proxy = task_map[fut]
+                self.cache.update(proxy, "good" if ok else "bad")
+                if ok and proxy not in self.pool:
                     self.pool.append(proxy)
+                    good_found += 1
+                    if good_found >= fast_fill:
+                        self._signal_ready()
+                        break
+
+            # Continue validating remaining proxies in background
+            remaining = {t: p for t, p in task_map.items() if not t.done()}
+            if remaining:
+                asyncio.create_task(self._finish_tasks(remaining))
+
             # Remove duplicates, limit pool size
             self.pool = list(dict.fromkeys(self.pool))
             if len(self.pool) > 150:
                 self.pool = random.sample(self.pool, 150)
             self.last_checked = time.time()
+            self.cache.save()
             print(f"[PROXY] Pool size: {len(self.pool)}")
 
     async def refresh(self) -> None:
@@ -94,6 +217,8 @@ class ProxyPool:
         async with self.lock:
             if proxy in self.pool:
                 self.pool.remove(proxy)
+            self.cache.update(proxy, "bad")
+            self.cache.save()
 
     def __len__(self) -> int:
         return len(self.pool)


### PR DESCRIPTION
## Summary
- support background proxy validation
- use as_completed to fill initial pool quickly
- expose fast-fill and ready callback options
- document proxy caching in README

## Testing
- `python -m compileall -q .`
- `python - <<'EOF'
from proxy_manager import ProxyPool
import asyncio
async def test_pool():
    pool = ProxyPool(min_proxies=5, fast_fill=2)
    await pool.refresh()
    print('pool ready', pool.pool_ready)
    print('pool size', len(pool))
asyncio.run(test_pool())
EOF` *(fails to validate proxies because httpbin.org is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686f65f6b8c08320a96806afe00a2f43