### PR TITLE
Enable configurable concurrency and proxy counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,22 @@ A hassle-free GUI tool to recursively download full-size images from any Copperm
 
    On any platform:
 
-   ```bash
-   python gallery_ripper.py
-   ```
+  ```bash
+  python gallery_ripper.py
+  ```
+
+### Command-line options
+
+The ripper now supports a few optional flags to control proxy usage and
+download concurrency:
+
+```bash
+python gallery_ripper.py --min-proxies 50 --validation-concurrency 20 --download-workers 4
+```
+
+- `--min-proxies` – minimum number of working proxies to keep in the pool
+- `--validation-concurrency` – how many proxies to validate in parallel
+- `--download-workers` – number of concurrent image download tasks
 
 ## License
 

--- a/proxy_manager.py
+++ b/proxy_manager.py
@@ -82,6 +82,7 @@ class ProxyPool:
         cache_file: str = PROXY_CACHE_FILE,
         fast_fill: int = 10,
         ready_callback: Optional[Callable[[], None]] = None,
+        validation_concurrency: int = VALIDATION_CONCURRENCY,
     ) -> None:
         self.cache = ProxyCache(cache_file)
         self.pool: list[str] = list(dict.fromkeys(self.cache.get_good_proxies()))
@@ -92,7 +93,7 @@ class ProxyPool:
         self.lock = asyncio.Lock()
         self.refresh_task: asyncio.Task | None = None
         self.last_checked: float = 0.0
-        self.sema = asyncio.Semaphore(VALIDATION_CONCURRENCY)
+        self.sema = asyncio.Semaphore(validation_concurrency)
         self.ready_event = asyncio.Event()
 
     def _signal_ready(self) -> None:


### PR DESCRIPTION
## Summary
- add command-line flags for proxy and worker counts
- pass those settings into `ProxyPool`
- implement asynchronous download workers
- document new options in README

## Testing
- `python -m py_compile proxy_manager.py async_http.py gallery_ripper.py`

------
https://chatgpt.com/codex/tasks/task_e_686f7181f8c48320a74c165e91502ed5