### PR TITLE
Fix proxy validation host and improve layout

### DIFF
--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -1289,7 +1289,7 @@ class GalleryRipperApp(tb.Window):
     def __init__(self):
         super().__init__(themename="darkly")
         self.title("Coppermine Gallery Ripper")
-        self.geometry("980x700")
+        self.geometry("1000x700")
         self.minsize(700, 480)
         self.albums_tree_data = None
         self.download_thread = None
@@ -1319,21 +1319,24 @@ class GalleryRipperApp(tb.Window):
         ttk.Entry(pathf, textvariable=self.path_var, width=50).pack(side="left", padx=5, expand=True, fill="x")
         ttk.Button(pathf, text="Browse...", command=self.select_folder).pack(side="left")
 
+        optionsf = ttk.Frame(control_frame)
+        optionsf.pack(fill="x")
+
         self.mimic_var = tk.BooleanVar(value=True)
-        mimic_chk = ttk.Checkbutton(pathf, text="Mimic human behavior", variable=self.mimic_var)
+        mimic_chk = ttk.Checkbutton(optionsf, text="Mimic human behavior", variable=self.mimic_var)
         mimic_chk.pack(side="left", padx=(10, 0))
 
         self.show_specials_var = tk.BooleanVar(value=False)
-        specials_chk = ttk.Checkbutton(pathf, text="Show special galleries", variable=self.show_specials_var, command=self.refresh_tree)
+        specials_chk = ttk.Checkbutton(optionsf, text="Show special galleries", variable=self.show_specials_var, command=self.refresh_tree)
         specials_chk.pack(side="left", padx=(10, 0))
 
         self.quick_scan_var = tk.BooleanVar(value=True)
-        quick_chk = ttk.Checkbutton(pathf, text="Quick scan", variable=self.quick_scan_var)
+        quick_chk = ttk.Checkbutton(optionsf, text="Quick scan", variable=self.quick_scan_var)
         quick_chk.pack(side="left", padx=(10, 0))
 
         self.use_proxies_var = tk.BooleanVar(value=settings.get("use_proxies", True))
         proxies_chk = ttk.Checkbutton(
-            pathf,
+            optionsf,
             text="Use proxies",
             variable=self.use_proxies_var,
             command=self.on_use_proxies_toggle,

--- a/proxy_manager.py
+++ b/proxy_manager.py
@@ -127,13 +127,13 @@ class ProxyPool:
 
     async def validate_proxy(self, proxy: str) -> bool:
         async with self.sema:
-            for test_url in ["http://httpbin.org/ip", "https://httpbin.org/ip"]:
+            for test_url in ["http://github.com", "https://github.com"]:
                 try:
                     async with aiohttp.ClientSession() as session:
                         async with session.get(
                             test_url, proxy=f"http://{proxy}", timeout=15
                         ) as resp:
-                            if resp.status == 200:
+                            if resp.status in {200, 301, 302}:
                                 print(f"[PROXY] OK: {proxy} on {test_url}")
                                 return True
                 except Exception:


### PR DESCRIPTION
## Summary
- proxy validation now uses GitHub instead of httpbin
- move checkboxes to new frame and widen default window to fit controls

## Testing
- `python -m py_compile proxy_manager.py gallery_ripper.py async_http.py`


------
https://chatgpt.com/codex/tasks/task_e_686f7a1755848320b4f2878c8a5fc0c0