### PR TITLE
Skip proxy HEAD on cached pages

### DIFF
--- a/async_http.py
+++ b/async_http.py
@@ -2,14 +2,14 @@ import aiohttp
 import asyncio
 from proxy_manager import ProxyPool
 
-async def head_with_proxy(url, proxy_pool: ProxyPool | None, headers=None, timeout=10):
+async def head_with_proxy(url, proxy_pool: ProxyPool | None, headers=None, timeout=5):
     headers = headers or {}
     if proxy_pool is None:
         connector = aiohttp.TCPConnector(ssl=False)
         async with aiohttp.ClientSession(connector=connector) as session:
             async with session.head(url, headers=headers, allow_redirects=True, timeout=timeout) as resp:
                 return resp.status, dict(resp.headers)
-    for attempt in range(5):
+    for attempt in range(3):
         proxy = await proxy_pool.get_proxy()
         proxy_url = f"http://{proxy}"
         try:

--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -407,6 +407,10 @@ def universal_get_all_candidate_images_from_album(album_url, rules, log=lambda m
 def fetch_html_cached(url, page_cache, log=lambda msg: None, quick_scan=True, indent=""):
     """Return HTML for *url* using the cache and indicate if it changed."""
     entry = page_cache.get(url)
+    # Skip the costly HEAD check when proxies are enabled and a cached entry exists
+    if entry and quick_scan and USE_PROXIES:
+        log(f"{indent}Using cached page (skipping proxy HEAD): {url}")
+        return entry["html"], False
     if entry and quick_scan:
         pool = get_pool_or_none()
         if USE_PROXIES and pool is None:


### PR DESCRIPTION
## Summary
- avoid expensive HEAD requests when a cached page is available while using proxies
- lower retries/timeouts for HEAD requests through proxies

## Testing
- `python -m py_compile gallery_ripper.py async_http.py proxy_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_686f86e205c8832088a5475e7c733053