### PR TITLE
Enable debug logging before GUI initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ python gallery_ripper.py --min-proxies 50 --validation-concurrency 20 --download
 - `--min-proxies` – minimum number of working proxies to keep in the pool
 - `--validation-concurrency` – how many proxies to validate in parallel
 - `--download-workers` – number of concurrent image download tasks
+- `--debug` – enable verbose DEBUG-level logging to help diagnose issues
 
 ## License
 


### PR DESCRIPTION
## Summary
- configure logging at startup so debug messages aren't lost
- update GUI init to reroute logs to the log pane
- document `--debug` option in README

## Testing
- `python3 -m py_compile gallery_ripper.py async_http.py proxy_manager.py`
- ❌ `python3 gallery_ripper.py --help` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_686f8e9d4c588320a4602f4744bcaf03