### PR TITLE
Log proxy pool events

### DIFF
--- a/proxy_manager.py
+++ b/proxy_manager.py
@@ -137,11 +137,11 @@ class ProxyPool:
                             test_url, proxy=f"http://{proxy}", timeout=15
                         ) as resp:
                             if resp.status in {200, 301, 302}:
-                                print(f"[PROXY] OK: {proxy} on {test_url}")
+                                log.info("[PROXY] OK: %s on %s", proxy, test_url)
                                 return True
                 except Exception:
                     continue
-        print(f"[PROXY] BAD: {proxy}")
+        log.info("[PROXY] BAD: %s", proxy)
         return False
 
     async def _finish_tasks(self, tasks: list[asyncio.Task]) -> None:
@@ -163,7 +163,7 @@ class ProxyPool:
 
     async def replenish(self, fast_fill: int | None = None) -> None:
         async with self.lock:
-            print("[PROXY] Replenishing proxies...")
+            log.info("[PROXY] Replenishing proxies...")
 
             fast_fill = fast_fill or self.fast_fill
 
@@ -174,7 +174,7 @@ class ProxyPool:
             if len(self.pool) >= fast_fill:
                 self.last_checked = time.time()
                 self.cache.save()
-                print(f"[PROXY] Fast pool fill from cache: {len(self.pool)} proxies.")
+                log.info("[PROXY] Fast pool fill from cache: %d proxies.", len(self.pool))
                 self._signal_ready()
                 return
 
@@ -222,7 +222,7 @@ class ProxyPool:
                 self.pool = random.sample(self.pool, 150)
             self.last_checked = time.time()
             self.cache.save()
-            print(f"[PROXY] Pool size: {len(self.pool)}")
+            log.info("[PROXY] Pool size: %d", len(self.pool))
 
     async def refresh(self) -> None:
         await self.replenish()


### PR DESCRIPTION
## Summary
- pipe proxy pool output to the root logger so proxy messages show in the GUI log

## Testing
- `python -m py_compile gallery_ripper.py proxy_manager.py async_http.py`

------
https://chatgpt.com/codex/tasks/task_e_6870397b330c8320b214fa9a6ebfea8d