### PR TITLE
Improve HTTP connection logs

### DIFF
--- a/async_http.py
+++ b/async_http.py
@@ -5,7 +5,9 @@ import time
 from proxy_manager import ProxyPool
 
 log = logging.getLogger("ripper.http")
-log.setLevel(logging.DEBUG)
+# Use INFO so important connection details show even when the root logger
+# runs at its default INFO level. More verbose timing info is logged at DEBUG.
+log.setLevel(logging.INFO)
 
 async def head_with_proxy(url, proxy_pool: ProxyPool | None, headers=None, timeout=5):
     headers = headers or {}
@@ -14,15 +16,25 @@ async def head_with_proxy(url, proxy_pool: ProxyPool | None, headers=None, timeo
         async with aiohttp.ClientSession(connector=connector) as session:
             async with session.head(url, headers=headers, allow_redirects=True, timeout=timeout) as resp:
                 return resp.status, dict(resp.headers)
-    for attempt in range(3):
+    attempts = 3
+    for attempt in range(1, attempts + 1):
         proxy = await proxy_pool.get_proxy()
         proxy_url = f"http://{proxy}"
         try:
+            log.info("[HEAD %d/%d] %s via %s", attempt, attempts, url, proxy)
             connector = aiohttp.TCPConnector(ssl=False)
             async with aiohttp.ClientSession(connector=connector) as session:
-                async with session.head(url, headers=headers, proxy=proxy_url, allow_redirects=True, timeout=timeout) as resp:
+                async with session.head(
+                    url,
+                    headers=headers,
+                    proxy=proxy_url,
+                    allow_redirects=True,
+                    timeout=timeout,
+                ) as resp:
+                    log.info("[HEAD] %s -> %s", url, resp.status)
                     return resp.status, dict(resp.headers)
-        except Exception:
+        except Exception as e:
+            log.info("[HEAD-ERR] %s via %s : %s", url, proxy, e)
             await proxy_pool.remove_proxy(proxy)
             continue
     raise Exception(f"Failed to HEAD {url}")
@@ -38,19 +50,22 @@ async def fetch_html(url, proxy_pool: ProxyPool | None, headers=None,
             proxy_url = f"http://{proxy}"
         t0 = time.time()
         try:
-            log.debug("[%s %d/%d] %s via %s", label, attempt, attempts,
-                      url, proxy or "DIRECT")
+            log.info("[%s %d/%d] %s via %s", label, attempt, attempts,
+                     url, proxy or "DIRECT")
             async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as s:
-                async with s.get(url, headers=headers,
-                                 proxy=proxy_url if proxy else None,
-                                 timeout=timeout,
-                                 allow_redirects=True) as r:
-                    log.debug("[HTTP] %s -> %s in %.1fs",
-                              url, r.status, time.time() - t0)
+                async with s.get(
+                    url,
+                    headers=headers,
+                    proxy=proxy_url if proxy else None,
+                    timeout=timeout,
+                    allow_redirects=True,
+                ) as r:
+                    log.info("[HTTP] %s -> %s in %.1fs",
+                             url, r.status, time.time() - t0)
                     if r.status == 200:
                         return await r.text(), dict(r.headers)
         except Exception as e:
-            log.debug("[HTTP-ERR] %s via %s : %s", url, proxy or "DIRECT", e)
+            log.info("[HTTP-ERR] %s via %s : %s", url, proxy or "DIRECT", e)
             if proxy_pool and proxy:
                 await proxy_pool.remove_proxy(proxy)
     raise Exception(f"Failed to fetch {url}")
@@ -64,18 +79,23 @@ async def download_with_proxy(url, out_path, proxy_pool: ProxyPool | None, refer
             proxy = await proxy_pool.get_proxy()
             proxy_url = f"http://{proxy}"
         try:
+            log.info("[IMG %d/%d] %s via %s", attempt, attempts, url, proxy or "DIRECT")
             connector = aiohttp.TCPConnector(ssl=False)
             async with aiohttp.ClientSession(connector=connector) as session:
-                async with session.get(url, proxy=proxy_url if proxy else None,
-                                       headers=headers, timeout=15) as resp:
+                async with session.get(
+                    url,
+                    proxy=proxy_url if proxy else None,
+                    headers=headers,
+                    timeout=15,
+                ) as resp:
                     if resp.status == 200 and resp.headers.get("Content-Type", "").startswith("image"):
-                        log.debug("[IMG %d/%d] %s via %s", attempt, attempts, url, proxy or "DIRECT")
+                        log.info("[IMG] %s -> %s", url, resp.status)
                         with open(out_path, "wb") as f:
                             async for chunk in resp.content.iter_chunked(16*1024):
                                 f.write(chunk)
                         return True
         except Exception as e:
-            log.debug("[HTTP-ERR] %s via %s : %s", url, proxy or "DIRECT", e)
+            log.info("[HTTP-ERR] %s via %s : %s", url, proxy or "DIRECT", e)
             if proxy_pool and proxy:
                 await proxy_pool.remove_proxy(proxy)
             continue


### PR DESCRIPTION
## Summary
- emit HTTP attempt info at INFO level for easier troubleshooting
- show HEAD/GET/IMG events and errors via proxies

## Testing
- `python -m py_compile gallery_ripper.py proxy_manager.py async_http.py`


------
https://chatgpt.com/codex/tasks/task_e_6870397b330c8320b214fa9a6ebfea8d