### PR TITLE
Add debug logging for HTTP fetches

### DIFF
--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -460,9 +460,12 @@ def fetch_html_cached(url, page_cache, log=lambda msg: None, quick_scan=True, in
         log(f"{indent}Using cached page: {url}")
         return entry["html"], False
 
+    pool = get_pool_or_none()
+    log(f"{indent}[DEBUG] Fetching {url} using proxy: {pool}")
     html, hdrs = run_async(
-        async_http.fetch_html(url, get_pool_or_none(), headers=session_headers, timeout=15)
+        async_http.fetch_html(url, pool, headers=session_headers, timeout=15)
     )
+    log(f"{indent}[DEBUG] Finished fetching {url}")
     page_cache[url] = {
         "html": html,
         "timestamp": time.time(),


### PR DESCRIPTION
## Summary
- improve visibility of which proxy is used
- log before and after calls to `fetch_html`
- log attempts and results for HTTP and image downloads

## Testing
- `python -m py_compile gallery_ripper.py async_http.py proxy_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_687047b248188320b94e3221591ac613