### PR TITLE
Improve robustness of HTML parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ beautifulsoup4
 ttkthemes
 ttkbootstrap
 aiohttp
+html5lib
 


### PR DESCRIPTION
## Summary
- add `html5lib` dependency
- introduce `safe_soup` helper that falls back when `BeautifulSoup` hangs
- use `safe_soup` everywhere instead of direct parser calls

## Testing
- `python -m py_compile gallery_ripper.py async_http.py proxy_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68704db25bd0832086d56246a89ac012