### PR TITLE
Add detailed download debugging

### DIFF
--- a/async_http.py
+++ b/async_http.py
@@ -81,6 +81,11 @@ async def download_with_proxy(url, out_path, proxy_pool: ProxyPool | None, refer
         if proxy_pool:
             proxy = await proxy_pool.get_proxy()
             proxy_url = f"http://{proxy}"
+        from gallery_ripper import USE_PROXIES as USE_PROXIES_FLAG
+        log.info(
+            f"[DEBUG] In async HTTP request task, proxies: {USE_PROXIES_FLAG}, proxy: {proxy}"
+        )
+        log.info(f"[DEBUG] About to download image {url} via proxy: {proxy}")
         log.debug("Attempting image %s via %s", url, proxy_url if proxy else "DIRECT")
         try:
             log.info("[IMG %d/%d] %s via %s", attempt, attempts, url, proxy or "DIRECT")

--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -68,6 +68,9 @@ logging.basicConfig(
     stream=sys.stdout,
 )
 
+# Logger for additional debug messages
+logger = logging.getLogger("ripper.download")
+
 # Global flag to control proxy usage
 USE_PROXIES = settings.get("use_proxies", True)
 
@@ -1290,6 +1293,9 @@ async def rip_galleries(
                 album_url, log=log, page_cache=pages, quick_scan=quick_scan
             )
         log(f"  Found {len(image_entries)} images in {album_name}.")
+        logger.info(
+            f"[DEBUG] Queuing {len(image_entries)} images for download, proxies: {USE_PROXIES}"
+        )
         if not image_entries:
             continue
         for entry_name, candidates, referer in image_entries:
@@ -1313,6 +1319,9 @@ async def rip_galleries(
     sem = asyncio.Semaphore(DOWNLOAD_WORKERS)
 
     async def worker(idx, album_name, album_path, candidate_urls, referer):
+        logger.info(
+            f"[DEBUG] Starting download worker, proxies: {USE_PROXIES}, images: {len(candidate_urls)}"
+        )
         if stop_flag and stop_flag.is_set():
             return
         if stats['downloaded'] > 0:


### PR DESCRIPTION
## Summary
- introduce a logger for download debugging
- log when images are queued
- log when download workers start
- log proxy usage for every image request

## Testing
- `python -m py_compile gallery_ripper.py async_http.py proxy_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_687056fc03f48320ad81fa7debe43e48