### PR TITLE
Improve proxy validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A hassle-free GUI tool to recursively download full-size images from any Copperm
 - One-click self-update from Git — pull new commits and restart automatically
 - Compatible with Python 3.10+
 - Dynamic proxy pool with caching — Harvests and validates free proxies automatically, caches results to skip dead proxies, and fast-fills the pool for quick startup; UI shows last check time
+- Proxy checks hit a random gallery URL from `proxy_manager.py` so only proxies that work on real targets are kept. Edit the `VALIDATION_URLS` list there to customize.
 - Verbose checkbox — Toggle DEBUG-level logging on demand while the app runs
 
 ## Limitations


### PR DESCRIPTION
## Summary
- add list of gallery URLs for proxy validation
- verify proxies against a random gallery URL instead of GitHub
- document how to customize the validation URLs

## Testing
- `python -m py_compile proxy_manager.py async_http.py gallery_ripper.py`

------
https://chatgpt.com/codex/tasks/task_e_68706dca3eac8320b93009da1ed012ac