### PR TITLE
Fix NameError in gallery discovery callback

### DIFF
--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -1800,7 +1800,7 @@ class GalleryRipperApp(tb.Window):
             self.after(0, self.insert_tree_root_safe, tree_data)
             self.after(0, lambda: self.log("Discovery complete! (cached & partial refreshed if needed)"))
         except Exception as e:
-            self.after(0, lambda: self.log(f"Discovery failed: {e}"))
+            self.after(0, lambda e=e: self.log(f"Discovery failed: {e}"))
 
     def insert_tree_node(self, parent, node, path=None):
         path = path or []


### PR DESCRIPTION
## Summary
- fix lambda capturing the exception in `do_discover`

## Testing
- `pytest -q`
- `python -m py_compile gallery_ripper.py async_http.py proxy_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6870ae9e9f148320ae475988add244bf