### PR TITLE
Improve 4chan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ A hassle-free GUI tool to recursively download full-size images from any Copperm
 ### 4chan Usage
 
 Enter `4chan` by itself to browse all boards, or paste any 4chan board or thread
-URL. Boards list their active threads and selecting a thread downloads all
-attached files (images, webms, mp4s).
+URL. Double-click a board to list its active threads. Use the new **Back** button
+to return to the board list. Selecting a thread downloads all attached files
+(images, webms, mp4s) into a `4chan/<board>/<subject> (id)` folder structure.
 
 ## Limitations
 

--- a/async_http.py
+++ b/async_http.py
@@ -116,7 +116,7 @@ async def download_with_proxy(url, out_path, proxy_pool: ProxyPool | None, refer
                 ) as resp:
                     log.debug("IMG headers: %s", headers)
                     log.debug("IMG cookies: %s", cj.filter_cookies(url))
-                    if resp.status == 200 and resp.headers.get("Content-Type", "").startswith("image"):
+                    if resp.status == 200:
                         log.info("[IMG] %s -> %s", url, resp.status)
                         with open(out_path, "wb") as f:
                             async for chunk in resp.content.iter_chunked(16*1024):


### PR DESCRIPTION
## Summary
- fix download helper to allow any content type
- store explicit path for 4chan threads
- allow entering board nodes with a double-click
- skip caching for 4chan content
- sanitize 4chan thread titles and add Back button for board navigation

## Testing
- `python -m py_compile gallery_ripper.py async_http.py proxy_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6870fa26f3a883209c4d1d61389cc14a