### PR TITLE
Enhance 4chan navigation and thread status

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ A hassle-free GUI tool to recursively download full-size images from any Copperm
 
 ### 4chan Usage
 
-Enter `4chan` by itself to browse all boards, or paste any 4chan board or thread
-URL. Double-click a board to list its active threads. Use the new **Back** button
-to return to the board list. Selecting a thread downloads all attached files
-(images, webms, mp4s) into a `4chan/<board>/<subject> (id)` folder structure.
+Enter `4chan` by itself to browse all boards, or paste any 4chan board or thread URL. Double-click a board to open it. Use the **Back** button to walk back up the navigation stack. Threads show a checkmark when fully downloaded or `[+n]` for new files. After a download finishes, the tree refreshes to reflect the new status. Selecting a thread downloads all attached files (images, webms, mp4s) into a `4chan/<board>/<subject> (id)` folder structure.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary
- add navigation stack for back button
- mark downloaded threads as complete or show how many images are missing
- refresh tree after download completes
- document improved navigation and status markers

## Testing
- `python -m py_compile gallery_ripper.py proxy_manager.py async_http.py`
- `python gallery_ripper.py --help` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_687103a67fe88320b97c4574e5031aac