### PR TITLE
Restore fast 4chan download path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4
 ttkthemes
 ttkbootstrap
+aiohttp


### PR DESCRIPTION
## Summary
- bypass cache when ripping from 4chan
- add asynchronous `download_4chan_image` helper using `aiohttp`
- implement dedicated 4chan async code path in `rip_galleries`
- avoid saving cache for 4chan in discovery
- add `aiohttp` requirement

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile gallery_ripper.py`


------
https://chatgpt.com/codex/tasks/task_e_68720a9c10cc8320b2dd522b282f9e68