### PR TITLE
Fix 4chan downloads to open new connection per file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ requests
 beautifulsoup4
 ttkthemes
 ttkbootstrap
-aiohttp


### PR DESCRIPTION
## Summary
- revert to sync downloads for 4chan images
- remove unused `aiohttp` dependency
- hardcode UA for 4chan downloads

## Testing
- `python -m py_compile gallery_ripper.py`


------
https://chatgpt.com/codex/tasks/task_e_6872151ea52c832080d8d9c75b2e259d