### PR TITLE
Add LiveJournal photo site support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Copperminer – A Gallery Ripper
 
-A hassle-free GUI tool to recursively download full-size images from any Coppermine-powered gallery—plus other sites using a simple rules engine (ThePlace2 included). No thumbnails, no junk—just the real full-size images, organized in folders to match the site’s gallery structure. Perfect for backing up fan galleries before they disappear.
+A hassle-free GUI tool to recursively download full-size images from any Coppermine-powered gallery—plus other sites using a simple rules engine (ThePlace2 and LiveJournal photos included). No thumbnails, no junk—just the real full-size images, organized in folders to match the site’s gallery structure. Perfect for backing up fan galleries before they disappear.
 
 ## Features
 
 - Point-and-click GUI — No command line needed, always-on dark mode
-- Intelligent discovery — Enter any gallery root or album URL (supports Coppermine and rule-based sites like ThePlace2)
+- Intelligent discovery — Enter any gallery root or album URL (supports Coppermine and rule-based sites like ThePlace2 or LiveJournal photos)
 - Album tree — Finds and displays all real albums for selection, ignoring “Last uploads”, “Most viewed”, and other virtual/special albums
 - Optional special galleries toggle — Include “Last uploads”, “Most viewed”, etc. only when you want them
 - Preserves structure — Downloads images into folders/subfolders that match the gallery’s layout
@@ -27,7 +27,7 @@ Enter `4chan` by itself to browse all boards, or paste any 4chan board or thread
 
 ## Limitations
 
-- Supports Coppermine and a small set of rule-based sites (initially ThePlace2): other galleries may fail
+- Supports Coppermine and a small set of rule-based sites (initially ThePlace2 and LiveJournal photos): other galleries may fail
 - No thumbnails or junk: heuristically skips thumbnails and UI icons to save only the original images
 - Not for commercial use: See license below
 

--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -148,6 +148,16 @@ DEFAULT_RULES = {
         "thumb_selector": ".pic-card a.link[href*='pic-']",
         "detail_image_selector": ".big-photo-wrapper a[href]",
     },
+    "livejournal": {
+        "domains": ["livejournal.com"],
+        # Albums use /photo/album/<id>
+        "root_album_selector": "a[href*='/photo/album/']",
+        "pagination_selector": "a[href*='page=']",
+        # Each thumbnail links to a /photo/item/<id> detail page
+        "thumb_selector": "a[href*='/photo/item/']",
+        # Detail pages show the image directly inside an <img>
+        "detail_image_selector": "img[src]",
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- support LiveJournal photo albums with a default ruleset
- mention LiveJournal in the README

## Testing
- `python -m py_compile gallery_ripper.py`

------
https://chatgpt.com/codex/tasks/task_e_687a65a3058c83209c0a1c0a7db15c91