### PR TITLE
Improve universal gallery adapter

### DIFF
--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -160,6 +160,18 @@ DEFAULT_RULES = {
     },
 }
 
+# --------------------------------------------------------------------------- #
+#  Small utility: get text for an <a> element even if it has no inner text.
+#  Many LiveJournal album links rely on title or aria-label instead.
+# --------------------------------------------------------------------------- #
+def _link_text(a):
+    return (
+        a.get_text(strip=True)
+        or a.get("title", "").strip()
+        or a.get("aria-label", "").strip()
+        or a.get("alt", "").strip()
+    )
+
 
 def select_universal_rules(url: str):
     """Return scraping rules for *url* if the domain is supported."""
@@ -257,6 +269,29 @@ def universal_discover_tree(root_url, rules, log=lambda msg: None, page_cache=No
         "albums": [],
     }
     albums = []
+
+    # ------------------------------------------------------------------- #
+    # 1) Generic discovery driven by CSS    (works for LiveJournal, etc.)
+    # ------------------------------------------------------------------- #
+    root_sel = rules.get("root_album_selector")
+    if root_sel:
+        for a in soup.select(root_sel):
+            href = a.get("href", "")
+            if not href:
+                continue
+            alb_url = urljoin(root_url, href)
+            if any(x["url"] == alb_url for x in albums):
+                continue
+            albums.append({
+                "type": "album",
+                "name": _link_text(a) or os.path.basename(href.rstrip("/")),
+                "url": alb_url,
+                "image_count": "?",
+            })
+
+    # ------------------------------------------------------------------- #
+    # 2) *ThePlace*-specific legacy code (kept unchanged, runs afterwards)
+    # ------------------------------------------------------------------- #
 
     # (1) If on /photos, get all A-Z letter pages
     letter_links = []
@@ -356,6 +391,13 @@ def universal_get_all_candidate_images_from_album(album_url, rules, log=lambda m
                 img = det_soup.select_one("img")
                 if img and "src" in img.attrs:
                     full_img = urljoin(detail_url, img["src"])
+            if not full_img and rules.get("detail_image_selector"):
+                tag = det_soup.select_one(rules["detail_image_selector"])
+                if tag:
+                    if tag.name == "img" and tag.get("src"):
+                        full_img = urljoin(detail_url, tag["src"])
+                    elif tag.get("href"):
+                        full_img = urljoin(detail_url, tag["href"])
             # Use filename as entry name
             if full_img and full_img not in seen:
                 seen.add(full_img)


### PR DESCRIPTION
## Summary
- handle album discovery generically in `universal_discover_tree`
- honour `detail_image_selector` when parsing image pages
- add helper `_link_text` for albums without inner text

## Testing
- `python -m py_compile gallery_ripper.py`


------
https://chatgpt.com/codex/tasks/task_e_687a6ecf8d648320869641a8291f0e30