### PR TITLE
Fix escaping for data attribute image regex

### DIFF
--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -1377,7 +1377,7 @@ def extract_all_displayimage_candidates(displayimage_url, log=lambda msg: None):
                 candidates.append(urljoin(base, m))
         for attr, val in tag.attrs.items():
             if attr.startswith("data") and isinstance(val, str) and re.search(
-                r"\.(jpe?g|png|gif|webp|bmp|tiff)(?:\?[^\s'"<>]*)?$",
+                r"\.(jpe?g|png|gif|webp|bmp|tiff)(?:\?[^\s'\"<>]*)?$",
                 val,
                 re.I,
             ):


### PR DESCRIPTION
## Summary
- escape the double quote inside the data attribute regex so the file parses correctly

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68ee300e15dc83208d4a12104ff9e9ee