### PR TITLE
[codex] Harden Yandex CAPTCHA handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Use **Similar** on any card to run a new Yandex reverse-image search from that r
 
 The **Probe sizes** button sends HEAD requests for visible cards that do not expose file-size metadata in Yandex's page data, then updates file-size sorting for those cards.
 
-If Yandex redirects automated requests to a CAPTCHA page, Copperminer now treats that as a blocked search instead of a fake zero-result discovery. It retries alternate Yandex hosts and, when `browser-cookie3` is installed, makes a best-effort retry with local Yandex cookies from Chrome, Edge, Firefox, Brave, Chromium, or Opera. If Yandex still blocks the request, open the logged request URL in your browser, solve the challenge, save the result page as HTML, then use **Yandex HTML** to import that saved page. The imported page uses the same parser, preview grid, sorting, and download pipeline.
+If Yandex redirects automated requests to a CAPTCHA page, Copperminer now treats that as a blocked search instead of a fake zero-result discovery. It retries alternate Yandex hosts by default. If you explicitly enable **Reuse Yandex browser cookies**, and `browser-cookie3` is installed, Copperminer can also make a best-effort retry with local Yandex cookies from Chrome, Edge, Firefox, Brave, Chromium, or Opera. If Yandex still blocks the request, open the logged request URL in your browser, solve the challenge, save the result page as HTML, then use **Yandex HTML** to import that saved page. The imported page uses the same parser, preview grid, sorting, and download pipeline.
 
 ## Limitations
 
 - Supports Coppermine, 4chan, Yandex Images text/reverse search, and a small set of rule-based sites (initially ThePlace2 and LiveJournal photos): other galleries may fail
-- Yandex support depends on Yandex's public HTML and can be rate-limited or CAPTCHA-gated by Yandex. Copperminer detects CAPTCHA/block pages, retries with alternate hosts and optional local browser cookies, and supports saved-HTML import as a manual fallback. Some result file sizes are only available after probing.
+- Yandex support depends on Yandex's public HTML and can be rate-limited or CAPTCHA-gated by Yandex. Copperminer detects CAPTCHA/block pages, retries with alternate hosts, supports explicit opt-in local browser cookie reuse, and supports saved-HTML import as a manual fallback. Some result file sizes are only available after probing.
 - No thumbnails or junk: heuristically skips thumbnails and UI icons to save only the original images
 - Not for commercial use: See license below
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A hassle-free GUI tool to recursively download full-size images from any Copperm
 - Select/Unselect all and Stop buttons — Quickly manage or cancel downloads
 - Resizable log panel — Drag to change how much space the log uses
 - 4chan support — Browse boards and threads to bulk download all attached media
-- Yandex Images support — Paste a keyword/search phrase, an image URL, or a Yandex Images search URL; preview thumbnail results, sort by resolution/size/domain/title, follow similar-image searches, and download the original/highest-resolution candidate URLs Yandex exposes
+- Yandex Images support — Paste a keyword/search phrase, an image URL, or a Yandex Images search URL; preview thumbnail results, sort by resolution/size/domain/title, follow similar-image searches, download the original/highest-resolution candidate URLs Yandex exposes, and import saved Yandex HTML when direct requests hit a CAPTCHA
 - Adaptive scraping engine — Handles custom Coppermine themes, multi-page albums, custom anti-hotlinking, and referer requirements
 - Smart caching engine — Saves each page and image list with ETag/Last-Modified info. Quick scans use HEAD requests so only changed pages are re-scraped.
 - History dropdown — Quickly reopen recently scanned galleries from cache
@@ -34,10 +34,12 @@ Use **Similar** on any card to run a new Yandex reverse-image search from that r
 
 The **Probe sizes** button sends HEAD requests for visible cards that do not expose file-size metadata in Yandex's page data, then updates file-size sorting for those cards.
 
+If Yandex redirects automated requests to a CAPTCHA page, Copperminer now treats that as a blocked search instead of a fake zero-result discovery. It retries alternate Yandex hosts and, when `browser-cookie3` is installed, makes a best-effort retry with local Yandex cookies from Chrome, Edge, Firefox, Brave, Chromium, or Opera. If Yandex still blocks the request, open the logged request URL in your browser, solve the challenge, save the result page as HTML, then use **Yandex HTML** to import that saved page. The imported page uses the same parser, preview grid, sorting, and download pipeline.
+
 ## Limitations
 
 - Supports Coppermine, 4chan, Yandex Images text/reverse search, and a small set of rule-based sites (initially ThePlace2 and LiveJournal photos): other galleries may fail
-- Yandex support depends on Yandex's public HTML. If Yandex changes its result markup, extraction may need parser updates. Some result file sizes are only available after probing.
+- Yandex support depends on Yandex's public HTML and can be rate-limited or CAPTCHA-gated by Yandex. Copperminer detects CAPTCHA/block pages, retries with alternate hosts and optional local browser cookies, and supports saved-HTML import as a manual fallback. Some result file sizes are only available after probing.
 - No thumbnails or junk: heuristically skips thumbnails and UI icons to save only the original images
 - Not for commercial use: See license below
 

--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -836,14 +836,34 @@ def fourchan_discover_tree(root_url, log=lambda msg: None, quick_scan=True):
     return node
 
 
-# --- Yandex Images reverse-search adapter ------------------------------------
+# --- Yandex Images adapter ----------------------------------------------------
 
 YANDEX_RESULT_PREFIX = "yandex-result:"
 YANDEX_QUERY_PREFIX = "yandex:"
+YANDEX_HTML_PREFIX = "yandex-html:"
 YANDEX_RESULT_LIMIT = 300
+YANDEX_SEARCH_HOSTS = ("yandex.com", "yandex.ru")
+YANDEX_CAPTCHA_MARKERS = (
+    "showcaptcha", "smartcaptcha", "are you not a robot", "not a robot",
+    "captcha", "access to our service has been temporarily restricted",
+)
+YANDEX_CHALLENGE_TITLE_MARKERS = (
+    "are you not a robot", "not a robot", "captcha", "blocked",
+    "access to our service has been temporarily restricted",
+)
 GENERIC_DOWNLOAD_BASENAMES = {
     "orig", "original", "image", "img", "file", "download", "download.php", "proxy",
 }
+
+
+class YandexBlockedError(RuntimeError):
+    """Raised when Yandex returns a CAPTCHA/block page instead of image results."""
+
+    def __init__(self, message, search_url="", captcha_url="", diagnostics=""):
+        super().__init__(message)
+        self.search_url = search_url
+        self.captcha_url = captcha_url
+        self.diagnostics = diagnostics
 
 
 def is_yandex_images_url(url: str) -> bool:
@@ -857,13 +877,20 @@ def is_yandex_images_url(url: str) -> bool:
 
 def is_yandex_query_url(url: str) -> bool:
     low = (url or "").strip().lower()
-    return low.startswith(YANDEX_QUERY_PREFIX) or is_yandex_images_url(url)
+    return (
+        low.startswith(YANDEX_QUERY_PREFIX)
+        or low.startswith(YANDEX_HTML_PREFIX)
+        or is_yandex_images_url(url)
+    )
 
 
 def yandex_query_source_url(url: str) -> str:
-    """Return the image URL or text query behind a yandex: or Yandex Images URL."""
+    """Return the image URL, text query, or local HTML path behind a Yandex input."""
     raw = (url or "").strip()
-    if raw.lower().startswith(YANDEX_QUERY_PREFIX):
+    low = raw.lower()
+    if low.startswith(YANDEX_HTML_PREFIX):
+        return raw[len(YANDEX_HTML_PREFIX):].strip().strip('"')
+    if low.startswith(YANDEX_QUERY_PREFIX):
         return raw.split(":", 1)[1].strip()
     if is_yandex_images_url(raw):
         parsed = urlparse(raw)
@@ -880,8 +907,11 @@ def yandex_query_source_url(url: str) -> str:
 
 
 def yandex_query_mode(url: str) -> str:
-    """Classify a Yandex discovery input as an existing URL, reverse-image search, or text search."""
+    """Classify a Yandex discovery input as HTML import, reverse-image search, or text search."""
     raw = (url or "").strip()
+    low = raw.lower()
+    if low.startswith(YANDEX_HTML_PREFIX):
+        return "html"
     if is_yandex_images_url(raw):
         parsed = urlparse(raw)
         qs = parse_qs(parsed.query)
@@ -896,22 +926,43 @@ def yandex_query_mode(url: str) -> str:
     return "text"
 
 
-def yandex_search_url(url: str) -> str:
-    """Build a Yandex Images search URL for either text search or reverse-image search."""
-    raw = (url or "").strip()
-    if is_yandex_images_url(raw):
-        return raw
-    query = yandex_query_source_url(raw)
+def _yandex_search_params(url: str) -> dict:
+    query = yandex_query_source_url(url)
     if _is_http_url(query):
-        params = {
+        return {
             "rpt": "imageview",
             "url": query,
             "img_url": query,
             "text": query,
         }
-    else:
-        params = {"text": query}
-    return "https://yandex.com/images/search?" + urlencode(params)
+    return {"text": query}
+
+
+def _replace_url_host(url: str, host: str) -> str:
+    parsed = urlparse(url)
+    return urlunparse((parsed.scheme or "https", host, parsed.path, parsed.params, parsed.query, parsed.fragment))
+
+
+def yandex_search_urls(url: str) -> list[str]:
+    """Build ordered Yandex Images search URLs for retry/fallback hosts."""
+    raw = (url or "").strip()
+    if is_yandex_images_url(raw):
+        urls = [raw]
+        for host in YANDEX_SEARCH_HOSTS:
+            variant = _replace_url_host(raw, host)
+            if variant not in urls:
+                urls.append(variant)
+        return urls
+
+    params = _yandex_search_params(raw)
+    query = urlencode(params)
+    return [f"https://{host}/images/search?{query}" for host in YANDEX_SEARCH_HOSTS]
+
+
+def yandex_search_url(url: str) -> str:
+    """Build the primary Yandex Images search URL for either text or reverse-image search."""
+    urls = yandex_search_urls(url)
+    return urls[0] if urls else (url or "")
 
 
 def yandex_reverse_search_url(url: str) -> str:
@@ -1260,6 +1311,44 @@ def _yandex_json_objects_near_markers(text: str, markers, max_objects: int = 250
                 return
 
 
+def _yandex_page_title(html: str) -> str:
+    try:
+        soup = BeautifulSoup(html or "", "html.parser")
+        return soup.title.get_text(" ", strip=True) if soup.title else ""
+    except Exception:
+        return ""
+
+
+def _yandex_is_challenge(html: str, response=None) -> bool:
+    final_url = (getattr(response, "url", "") or "").lower() if response is not None else ""
+    title = _yandex_page_title(html).lower()
+    low = (html or "").lower()
+    if "showcaptcha" in final_url or "smartcaptcha" in final_url:
+        return True
+    if any(marker in title for marker in YANDEX_CHALLENGE_TITLE_MARKERS):
+        return True
+    # Body checks stay limited to strong CAPTCHA markers. A normal result page can
+    # contain generic strings like "robot" or "blocked" in scripts or metadata.
+    return any(marker in low for marker in YANDEX_CAPTCHA_MARKERS)
+
+
+def _yandex_has_serp_markers(html: str) -> bool:
+    low = (html or "").lower()
+    return any(
+        marker in low
+        for marker in (
+            "serp-item",
+            "images-touch-serp-item",
+            "img_href",
+            "origurl",
+            "originurl",
+            "serp-list",
+            "cbir",
+            "imagescontentimage",
+        )
+    )
+
+
 def _yandex_page_diagnostics(html: str, response=None) -> str:
     parts = []
     if response is not None:
@@ -1269,21 +1358,123 @@ def _yandex_page_diagnostics(html: str, response=None) -> str:
             parts.append(f"final_url={final_url[:180]}")
     if html is not None:
         parts.append(f"bytes={len(html.encode('utf-8', errors='ignore'))}")
-        soup = BeautifulSoup(html or "", "html.parser")
-        title = soup.title.get_text(" ", strip=True) if soup.title else ""
+        title = _yandex_page_title(html)
         if title:
             parts.append(f"title={title[:120]}")
-        low = (html or "").lower()
-        if any(marker in low for marker in ("captcha", "smartcaptcha", "showcaptcha", "robot", "blocked")):
+        if _yandex_is_challenge(html, response=response):
             parts.append("possible_challenge_or_block=1")
         marker_counts = []
-        for marker in ("serp-item", "img_href", "origUrl", "preview"):
+        low = (html or "").lower()
+        for marker in ("serp-item", "img_href", "origUrl", "preview", "serp-list", "cbir"):
             count = low.count(marker.lower())
             if count:
                 marker_counts.append(f"{marker}:{count}")
         if marker_counts:
             parts.append("markers=" + ",".join(marker_counts))
     return "; ".join(parts)
+
+
+def _yandex_browser_cookies(log=lambda msg: None):
+    """Best-effort import of local browser cookies for Yandex challenge sessions."""
+    try:
+        import browser_cookie3  # Optional dependency; see requirements.txt.
+    except Exception as exc:
+        log(f"Yandex browser-cookie retry unavailable: browser_cookie3 is not installed/importable ({exc}).")
+        return None
+
+    jar = requests.cookies.RequestsCookieJar()
+    loaded = []
+    domains = (".yandex.com", "yandex.com", ".yandex.ru", "yandex.ru", ".ya.ru", "ya.ru")
+    loaders = (
+        ("Chrome", getattr(browser_cookie3, "chrome", None)),
+        ("Edge", getattr(browser_cookie3, "edge", None)),
+        ("Firefox", getattr(browser_cookie3, "firefox", None)),
+        ("Brave", getattr(browser_cookie3, "brave", None)),
+        ("Chromium", getattr(browser_cookie3, "chromium", None)),
+        ("Opera", getattr(browser_cookie3, "opera", None)),
+    )
+    for browser_name, loader in loaders:
+        if loader is None:
+            continue
+        before = len(jar)
+        for domain in domains:
+            try:
+                cookie_jar = loader(domain_name=domain)
+            except Exception:
+                continue
+            try:
+                for cookie in cookie_jar:
+                    jar.set_cookie(cookie)
+            except Exception:
+                continue
+        if len(jar) > before:
+            loaded.append(browser_name)
+
+    if loaded:
+        log(f"Yandex browser-cookie retry loaded {len(jar)} cookie(s) from: {', '.join(sorted(set(loaded)))}.")
+        return jar
+    log("Yandex browser-cookie retry found no usable Yandex cookies in local browsers.")
+    return None
+
+
+def _yandex_headers_for(search_url: str) -> dict:
+    parsed = urlparse(search_url)
+    origin = f"{parsed.scheme}://{parsed.netloc}" if parsed.scheme and parsed.netloc else "https://yandex.com"
+    return {
+        "User-Agent": DEFAULT_USER_AGENT,
+        "Referer": origin + "/images/",
+        "Accept-Language": "en-US,en;q=0.9,ru;q=0.8",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "same-origin",
+        "Sec-Fetch-User": "?1",
+    }
+
+
+def _yandex_fetch_search_html(search_urls, log=lambda msg: None):
+    """Fetch a Yandex result page, retrying alternate hosts and optional browser cookies."""
+    blocked = []
+    cookie_modes = [(None, "plain session")]
+
+    for mode_idx, (cookies, label) in enumerate(cookie_modes):
+        for search_url in search_urls:
+            headers = _yandex_headers_for(search_url)
+            try:
+                resp = session.get(search_url, headers=headers, cookies=cookies, timeout=25, allow_redirects=True)
+                resp.raise_for_status()
+            except Exception as exc:
+                log(f"Yandex request failed via {label}: {search_url} ({exc})")
+                continue
+
+            if _yandex_is_challenge(resp.text, response=resp):
+                diag = _yandex_page_diagnostics(resp.text, response=resp)
+                blocked.append((search_url, getattr(resp, "url", "") or search_url, diag))
+                log(f"Yandex returned challenge/block page via {label}: {diag}")
+                continue
+
+            if mode_idx > 0:
+                log(f"Yandex request succeeded with {label}: {search_url}")
+            return resp, search_url
+
+        # Only attempt browser cookies after the plain session is blocked/empty.
+        if mode_idx == 0:
+            browser_cookies = _yandex_browser_cookies(log=log)
+            if browser_cookies:
+                cookie_modes.append((browser_cookies, "browser cookies"))
+
+    if blocked:
+        primary_search, captcha_url, diagnostics = blocked[-1]
+        raise YandexBlockedError(
+            "Yandex returned a CAPTCHA/block page instead of image results. "
+            "Open the Yandex request URL in your browser, solve the challenge if shown, then retry. "
+            "If requests are still blocked, save the browser result page as HTML and import it with the Yandex HTML button.",
+            search_url=primary_search,
+            captcha_url=captcha_url,
+            diagnostics=diagnostics,
+        )
+    raise RuntimeError("Yandex request failed for every candidate URL.")
 
 
 def yandex_extract_results(html: str, search_url: str, log=lambda msg: None):
@@ -1381,27 +1572,63 @@ def yandex_extract_results(html: str, search_url: str, log=lambda msg: None):
 
 
 def yandex_discover_tree(root_url, log=lambda msg: None, quick_scan=True):
-    search_url = yandex_search_url(root_url)
     query_url = yandex_query_source_url(root_url)
     mode = yandex_query_mode(root_url)
-    if mode == "text":
-        log(f"Yandex image text search: {query_url}")
-    elif mode == "reverse":
-        log(f"Yandex reverse image search: {query_url}")
+
+    response = None
+    search_url = yandex_search_url(root_url)
+    if mode == "html":
+        html_path = query_url
+        log(f"Yandex HTML import: {html_path}")
+        try:
+            with open(html_path, "r", encoding="utf-8", errors="ignore") as f:
+                html = f.read()
+        except Exception as exc:
+            raise RuntimeError(f"Failed to read Yandex HTML file: {exc}")
+        # Use Yandex as the parser base URL so relative / protocol-relative assets
+        # in browser-saved HTML resolve the same way as a live Yandex page.
+        search_url = "https://yandex.com/images/search?imported_html=1"
     else:
-        log(f"Yandex Images search URL: {search_url}")
-    log(f"Yandex request URL: {search_url}")
-    headers = {
-        "Referer": "https://yandex.com/images/",
-        "Accept-Language": "en-US,en;q=0.9,ru;q=0.8",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-        "Upgrade-Insecure-Requests": "1",
-    }
-    resp = session.get(search_url, headers=headers, timeout=25)
-    resp.raise_for_status()
-    results = yandex_extract_results(resp.text, search_url, log=log)
+        search_urls = yandex_search_urls(root_url)
+        if mode == "text":
+            log(f"Yandex image text search: {query_url}")
+        elif mode == "reverse":
+            log(f"Yandex reverse image search: {query_url}")
+        else:
+            log(f"Yandex Images search URL: {search_url}")
+        for idx, candidate in enumerate(search_urls, 1):
+            suffix = "" if idx == 1 else " (fallback)"
+            log(f"Yandex request URL{suffix}: {candidate}")
+        response, search_url = _yandex_fetch_search_html(search_urls, log=log)
+        html = response.text
+
+    if _yandex_is_challenge(html, response=response):
+        diagnostics = _yandex_page_diagnostics(html, response=response)
+        raise YandexBlockedError(
+            "Yandex returned a CAPTCHA/block page instead of image results.",
+            search_url=search_url,
+            captcha_url=getattr(response, "url", "") if response is not None else search_url,
+            diagnostics=diagnostics,
+        )
+    if mode == "html" and not _yandex_has_serp_markers(html):
+        diagnostics = _yandex_page_diagnostics(html, response=response)
+        raise RuntimeError(
+            "Imported Yandex HTML does not look like a saved Yandex Images result page. "
+            "Open a Yandex Images result page in your browser, save that page as HTML, "
+            "then import the saved file. Diagnostics: " + diagnostics
+        )
+
+    results = yandex_extract_results(html, search_url, log=log)
     if not results:
-        log("Yandex empty-result diagnostics: " + _yandex_page_diagnostics(resp.text, response=resp))
+        diag = _yandex_page_diagnostics(html, response=response)
+        log("Yandex empty-result diagnostics: " + diag)
+        # Do not silently treat a no-result parser path as success when the page
+        # clearly was not a usable image SERP. This is how CAPTCHA pages used to
+        # become a fake successful discovery with zero albums.
+        if mode != "html" and (response is not None) and not _yandex_has_serp_markers(html):
+            raise RuntimeError(
+                "Yandex returned no parseable image results. Diagnostics: " + diag
+            )
 
     query_label = os.path.basename(urlparse(query_url).path) or query_url
     query_label = sanitize_folder_name(unquote(query_label))[:80] or "query"
@@ -2954,6 +3181,7 @@ class GalleryRipperApp(tb.Window):
         url_entry.pack(side="left", padx=5, expand=True, fill="x")
         ttk.Button(urlf, text="Discover Galleries", command=self.discover_albums).pack(side="left")
         ttk.Button(urlf, text="Yandex Search", command=self.discover_yandex_from_url).pack(side="left", padx=(5, 0))
+        ttk.Button(urlf, text="Yandex HTML", command=self.import_yandex_html).pack(side="left", padx=(5, 0))
         ttk.Button(urlf, text="History", command=self.show_history).pack(side="left", padx=(5, 0))
 
         pathf = ttk.Frame(control_frame)
@@ -3090,6 +3318,16 @@ class GalleryRipperApp(tb.Window):
             return
         if not is_yandex_query_url(url):
             self.url_var.set(YANDEX_QUERY_PREFIX + url)
+        self.discover_albums()
+
+    def import_yandex_html(self):
+        path = filedialog.askopenfilename(
+            title="Import saved Yandex Images HTML",
+            filetypes=[("HTML files", "*.html *.htm"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        self.url_var.set(YANDEX_HTML_PREFIX + path)
         self.discover_albums()
 
     def show_history(self):
@@ -3588,8 +3826,29 @@ class GalleryRipperApp(tb.Window):
                 self.yandex_results = tree_data.get("yandex_results", [])
                 self.after(0, lambda results=self.yandex_results: self.show_yandex_preview(results))
             self.after(0, lambda: self.log("Discovery complete! (cached & partial refreshed if needed)"))
+        except YandexBlockedError as e:
+            self.after(0, lambda err=e: self.handle_yandex_blocked(err))
         except Exception as e:
             self.after(0, lambda: self.log(f"Discovery failed: {e}"))
+
+    def handle_yandex_blocked(self, err):
+        details = f"Discovery failed: {err}"
+        if err.diagnostics:
+            details += f"\nDiagnostics: {err.diagnostics}"
+        if err.search_url:
+            details += f"\nRequest URL: {err.search_url}"
+        if err.captcha_url and err.captcha_url != err.search_url:
+            details += f"\nChallenge URL: {err.captcha_url}"
+        details += "\n\nUse the Yandex HTML button after saving a solved browser result page if direct requests remain blocked."
+        self.log(details)
+        if err.search_url and messagebox.askyesno(
+            "Yandex blocked automated request",
+            "Yandex returned a CAPTCHA/block page instead of image results.\n\n"
+            "Open the request URL in your browser now?\n\n"
+            "After solving it, retry the search. If direct requests still fail, "
+            "save the browser result page as HTML and import it with the Yandex HTML button.",
+        ):
+            webbrowser.open(err.search_url)
 
     def insert_tree_node(self, parent, node, path=None):
         path = path or []

--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -843,9 +843,10 @@ YANDEX_QUERY_PREFIX = "yandex:"
 YANDEX_HTML_PREFIX = "yandex-html:"
 YANDEX_RESULT_LIMIT = 300
 YANDEX_SEARCH_HOSTS = ("yandex.com", "yandex.ru")
-YANDEX_CAPTCHA_MARKERS = (
-    "showcaptcha", "smartcaptcha", "are you not a robot", "not a robot",
-    "captcha", "access to our service has been temporarily restricted",
+YANDEX_CAPTCHA_BODY_MARKERS = (
+    "showcaptcha", "smartcaptcha", "checkcaptcha", "captcha__",
+    "captcha-form", "advanced-captcha",
+    "access to our service has been temporarily restricted",
 )
 YANDEX_CHALLENGE_TITLE_MARKERS = (
     "are you not a robot", "not a robot", "captcha", "blocked",
@@ -1327,9 +1328,9 @@ def _yandex_is_challenge(html: str, response=None) -> bool:
         return True
     if any(marker in title for marker in YANDEX_CHALLENGE_TITLE_MARKERS):
         return True
-    # Body checks stay limited to strong CAPTCHA markers. A normal result page can
-    # contain generic strings like "robot" or "blocked" in scripts or metadata.
-    return any(marker in low for marker in YANDEX_CAPTCHA_MARKERS)
+    # Body checks stay limited to structural CAPTCHA markers. Normal SERPs can
+    # contain generic query/result text such as "captcha", "robot", or "blocked".
+    return any(marker in low for marker in YANDEX_CAPTCHA_BODY_MARKERS)
 
 
 def _yandex_has_serp_markers(html: str) -> bool:
@@ -3829,7 +3830,7 @@ class GalleryRipperApp(tb.Window):
         except YandexBlockedError as e:
             self.after(0, lambda err=e: self.handle_yandex_blocked(err))
         except Exception as e:
-            self.after(0, lambda: self.log(f"Discovery failed: {e}"))
+            self.after(0, lambda err=e: self.log(f"Discovery failed: {err}"))
 
     def handle_yandex_blocked(self, err):
         details = f"Discovery failed: {err}"

--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -1434,9 +1434,10 @@ def _yandex_headers_for(search_url: str) -> dict:
     }
 
 
-def _yandex_fetch_search_html(search_urls, log=lambda msg: None):
+def _yandex_fetch_search_html(search_urls, log=lambda msg: None, reuse_browser_cookies=False):
     """Fetch a Yandex result page, retrying alternate hosts and optional browser cookies."""
     blocked = []
+    non_serp = []
     cookie_modes = [(None, "plain session")]
 
     for mode_idx, (cookies, label) in enumerate(cookie_modes):
@@ -1454,16 +1455,23 @@ def _yandex_fetch_search_html(search_urls, log=lambda msg: None):
                 blocked.append((search_url, getattr(resp, "url", "") or search_url, diag))
                 log(f"Yandex returned challenge/block page via {label}: {diag}")
                 continue
+            if not _yandex_has_serp_markers(resp.text):
+                diag = _yandex_page_diagnostics(resp.text, response=resp)
+                non_serp.append((search_url, diag))
+                log(f"Yandex returned a non-SERP page via {label}: {diag}")
+                continue
 
             if mode_idx > 0:
                 log(f"Yandex request succeeded with {label}: {search_url}")
             return resp, search_url
 
         # Only attempt browser cookies after the plain session is blocked/empty.
-        if mode_idx == 0:
+        if mode_idx == 0 and reuse_browser_cookies:
             browser_cookies = _yandex_browser_cookies(log=log)
             if browser_cookies:
                 cookie_modes.append((browser_cookies, "browser cookies"))
+        elif mode_idx == 0:
+            log("Yandex browser-cookie retry skipped; browser cookie reuse is not enabled.")
 
     if blocked:
         primary_search, captcha_url, diagnostics = blocked[-1]
@@ -1475,6 +1483,9 @@ def _yandex_fetch_search_html(search_urls, log=lambda msg: None):
             captcha_url=captcha_url,
             diagnostics=diagnostics,
         )
+    if non_serp:
+        _, diagnostics = non_serp[-1]
+        raise RuntimeError("Yandex returned no usable image result page. Diagnostics: " + diagnostics)
     raise RuntimeError("Yandex request failed for every candidate URL.")
 
 
@@ -1572,7 +1583,7 @@ def yandex_extract_results(html: str, search_url: str, log=lambda msg: None):
     return results[:YANDEX_RESULT_LIMIT]
 
 
-def yandex_discover_tree(root_url, log=lambda msg: None, quick_scan=True):
+def yandex_discover_tree(root_url, log=lambda msg: None, quick_scan=True, reuse_browser_cookies=False):
     query_url = yandex_query_source_url(root_url)
     mode = yandex_query_mode(root_url)
 
@@ -1600,11 +1611,21 @@ def yandex_discover_tree(root_url, log=lambda msg: None, quick_scan=True):
         for idx, candidate in enumerate(search_urls, 1):
             suffix = "" if idx == 1 else " (fallback)"
             log(f"Yandex request URL{suffix}: {candidate}")
-        response, search_url = _yandex_fetch_search_html(search_urls, log=log)
+        response, search_url = _yandex_fetch_search_html(
+            search_urls,
+            log=log,
+            reuse_browser_cookies=reuse_browser_cookies,
+        )
         html = response.text
 
     if _yandex_is_challenge(html, response=response):
         diagnostics = _yandex_page_diagnostics(html, response=response)
+        if mode == "html":
+            raise RuntimeError(
+                "Imported Yandex HTML is a CAPTCHA/block page, not a saved image result page. "
+                "Open a Yandex Images result page in your browser after solving the challenge, "
+                "save that result page as HTML, then import the saved file. Diagnostics: " + diagnostics
+            )
         raise YandexBlockedError(
             "Yandex returned a CAPTCHA/block page instead of image results.",
             search_url=search_url,
@@ -2131,7 +2152,13 @@ def _build_url_map(node, mapping=None):
     return mapping
 
 
-def discover_or_load_gallery_tree(root_url, log, quick_scan=True, force_refresh=False):
+def discover_or_load_gallery_tree(
+    root_url,
+    log,
+    quick_scan=True,
+    force_refresh=False,
+    yandex_reuse_browser_cookies=False,
+):
     """Discover galleries using cached pages when possible."""
     pages, cached_tree = load_page_cache(root_url)
     if force_refresh:
@@ -2157,6 +2184,7 @@ def discover_or_load_gallery_tree(root_url, log, quick_scan=True, force_refresh=
             root_url,
             log=log,
             quick_scan=quick_scan,
+            reuse_browser_cookies=yandex_reuse_browser_cookies,
         )
     elif site_type == "4chan":
         tree = fourchan_discover_tree(
@@ -3206,6 +3234,27 @@ class GalleryRipperApp(tb.Window):
         quick_chk = ttk.Checkbutton(optionsf, text="Quick scan", variable=self.quick_scan_var)
         quick_chk.pack(side="left", padx=(10, 0))
 
+        self.yandex_reuse_browser_cookies_var = tk.BooleanVar(
+            value=bool(settings.get("yandex_reuse_browser_cookies", False))
+        )
+
+        def save_yandex_cookie_setting():
+            current = load_settings()
+            current["yandex_reuse_browser_cookies"] = self.yandex_reuse_browser_cookies_var.get()
+            save_settings(current)
+
+        yandex_cookie_chk = ttk.Checkbutton(
+            optionsf,
+            text="Reuse Yandex browser cookies",
+            variable=self.yandex_reuse_browser_cookies_var,
+            command=save_yandex_cookie_setting,
+        )
+        yandex_cookie_chk.pack(side="left", padx=(10, 0))
+        ToolTip(
+            yandex_cookie_chk,
+            text="Opt in to retry blocked Yandex searches with local browser cookies.",
+        )
+
         self.download_workers_var = IntVar(value=DOWNLOAD_WORKERS)
 
         def update_worker_label(value):
@@ -3814,13 +3863,24 @@ class GalleryRipperApp(tb.Window):
         self.thread_safe_log(f"Discovering albums from: {url}")
         self.tree.delete(*self.tree.get_children())
         quick = self.quick_scan_var.get()
-        self.discovery_thread = threading.Thread(target=self.do_discover, args=(url, quick), daemon=True)
+        reuse_browser_cookies = self.yandex_reuse_browser_cookies_var.get()
+        self.discovery_thread = threading.Thread(
+            target=self.do_discover,
+            args=(url, quick, reuse_browser_cookies),
+            daemon=True,
+        )
         self.discovery_thread.start()
         self.update_nav_buttons()
 
-    def do_discover(self, url, quick):
+    def do_discover(self, url, quick, reuse_browser_cookies=False):
         try:
-            tree_data = discover_or_load_gallery_tree(url, self.thread_safe_log, quick_scan=quick, force_refresh=not quick)
+            tree_data = discover_or_load_gallery_tree(
+                url,
+                self.thread_safe_log,
+                quick_scan=quick,
+                force_refresh=not quick,
+                yandex_reuse_browser_cookies=reuse_browser_cookies,
+            )
             self.albums_tree_data = tree_data
             self.after(0, self.insert_tree_root_safe, tree_data)
             if tree_data.get("adapter") == "yandex":

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ beautifulsoup4
 ttkthemes
 ttkbootstrap
 Pillow>=12.2.0
+browser-cookie3>=0.20.1


### PR DESCRIPTION
## Summary
- detect Yandex CAPTCHA/block pages before parsing them as image results
- retry Yandex searches across alternate hosts and optional local browser cookies
- add saved Yandex HTML import as a manual fallback when direct requests stay blocked

## Validation
- `python3 -m py_compile gallery_ripper.py`

Repository tests were not run per instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Yandex HTML import option and import button for blocked searches
  * Multi-host retry/fallback for Yandex searches and user prompt to open blocked URLs
  * Optional reuse of local browser cookies for retrying blocked searches
  * Enhanced reverse-image capabilities: keyword/search/reverse-image inputs, thumbnail preview, sorting, similar-image detection, and selecting original/high-res candidates

* **Bug Fixes**
  * Improved CAPTCHA/block detection with clearer diagnostics and handling

* **Documentation**
  * Expanded README covering Yandex features, CAPTCHA handling, and saved-HTML import workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xmarre/Copperminer/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->